### PR TITLE
fix: make install robust under umask 077 (test + MTProxy binary perms)

### DIFF
--- a/deploy/install-mtproxy.sh
+++ b/deploy/install-mtproxy.sh
@@ -48,6 +48,15 @@ if [[ ! -x "$source_directory/objs/bin/mtproto-proxy" ]] ||
 	rm -rf "$temporary"
 fi
 
+# install.sh runs with umask 077, so make's output keeps owner-only
+# permissions; the unprivileged mtproxy service user must be able to
+# traverse the tree and execute the binary. Normalize permissions
+# unconditionally: when the guard above skipped a rebuild (a previous
+# failed run may already have left /opt/MTProxy with a root-owned
+# 0700 binary), the tree is reused as-is and still needs this fix.
+chown -R root:root "$source_directory"
+chmod -R a+rX "$source_directory"
+
 install -d -o root -g mtproxy -m 0750 /etc/mtproxy
 secret_temp="$(mktemp /etc/mtproxy/proxy-secret.XXXXXX)"
 config_temp="$(mktemp /etc/mtproxy/proxy-multi.conf.XXXXXX)"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -234,6 +234,12 @@ func TestLoadAcceptsSystemdCredentialReadPermissions(t *testing.T) {
 	if err := os.WriteFile(profiles, []byte(content), 0444); err != nil {
 		t.Fatal(err)
 	}
+	// Force the intended mode: install.sh runs tests under umask 077,
+	// which would otherwise strip the group/other read bits and make the
+	// "outside a credential directory" assertion below vacuously pass.
+	if err := os.Chmod(profiles, 0444); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("CREDENTIALS_DIRECTORY", credentials)
 	server := `{"public_hostname":"proxy.example.com","public_dir":"public","profiles_file":"credentials/profiles.json"}`
 	path := filepath.Join(directory, "config.json")


### PR DESCRIPTION
## Summary

`deploy/install.sh` sets `umask 077` at the top, which breaks two things on a fresh install:

1. **`go test ./...` fails** — `TestLoadAcceptsSystemdCredentialReadPermissions` in `internal/config` writes `profiles.json` with `os.WriteFile(..., 0444)`, but under umask 077 the file is actually created `0400`. The second assertion ("group/other-readable profiles file outside a credential directory was accepted") then vacuously passes, the test fails, and the installer aborts before installing `tproxy-server`.

2. **MTProxy fails to start with `203/EXEC`** — `install-mtproxy.sh` builds the official MTProxy as the `mtproxy` user and then `chown -R root:root`s the tree, but never adds group/other permissions. Under umask 077 the binary and directories stay `0700 root`, so `mtproxy.service` (`User=mtproxy`) cannot traverse `/opt/MTProxy/objs` or execute the binary. `tproxy-server` then never becomes ready (`/readyz` = 503) and the installer exits with "tproxy-server did not become ready".

## Changes

- `internal/config/config_test.go`: `os.Chmod(profiles, 0444)` after write, so the test exercises the intended permission handling regardless of umask.
- `deploy/install-mtproxy.sh`: `chmod -R a+rX` after `chown -R root:root`, so the unprivileged `mtproxy` service user can traverse the tree and execute the binary.

## Test Plan

Verified on a production Ubuntu 22.04 x86_64 server where the previous install failed at both points:

```bash
umask 077 && go test ./... -count=1   # all pass
# after fix: mtproxy active, /readyz = 200, install completes
```

Also verified end-to-end: `tg://webproxy` link works from Telegram Desktop 7.1.1.